### PR TITLE
Bug: mb_mime_encodeheader

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -1541,11 +1541,10 @@ class Message {
 
 		if ($this->charset === 'UTF-8')
 		{
-			if (MB_ENABLED === TRUE)
-			{
-				return mb_encode_mimeheader($str, $this->charset, 'Q', $this->crlf);
-			}
-			elseif (ICONV_ENABLED === TRUE)
+			// Note: We used to have mb_encode_mimeheader() as the first choice
+			//       here, but it turned out to be buggy and unreliable. DO NOT
+			//       re-add it! -- Narf
+			if (ICONV_ENABLED === TRUE)
 			{
 				$output = @iconv_mime_encode('', $str,
 					array(
@@ -1567,6 +1566,10 @@ class Message {
 				}
 
 				$chars = iconv_strlen($str, 'UTF-8');
+			}
+			elseif (MB_ENABLED === TRUE)
+			{
+				$chars = mb_strlen($str, 'UTF-8');
 			}
 		}
 


### PR DESCRIPTION
Email wouldn't always have proper quoted-printable encoding due to a bug in PHP's own mb_mime_encodeheader() function.

https://github.com/bcit-ci/CodeIgniter/commit/3368cebeb6682013c44be7a03d3b3dac0f5c8973